### PR TITLE
Ensure settings fields are not empty when updateing baseurl, title.

### DIFF
--- a/src/main/java/de/aservo/confapi/crowd/service/SettingsServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/crowd/service/SettingsServiceImpl.java
@@ -36,8 +36,12 @@ public class SettingsServiceImpl implements SettingsService {
 
     @Override
     public SettingsBean setSettings(SettingsBean settingsBean) {
-        propertyManager.setBaseUrl(settingsBean.getBaseUrl());
-        propertyManager.setDeploymentTitle(settingsBean.getTitle());
+        if (settingsBean.getBaseUrl() != null) {
+            propertyManager.setBaseUrl(settingsBean.getBaseUrl());
+        }
+        if (settingsBean.getTitle() != null) {
+            propertyManager.setDeploymentTitle(settingsBean.getTitle());
+        }
         return getSettings();
     }
 


### PR DESCRIPTION
It might seem as unexpected behaviour to some users when the settings fields, for which no value was provided in the REST call, are set to empty string. Therefore check for null objects before modifying the fields.