### PR TITLE
Upgrade Crowd to version 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>confapi-crowd-plugin</artifactId>
-    <version>0.0.10-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>ConfAPI for Crowd</name>
@@ -60,14 +60,14 @@
     </developers>
 
     <properties>
-        <crowd.version>4.4.0</crowd.version>
+        <crowd.version>5.1.3</crowd.version>
         <crowd.data.version>4.4.0</crowd.data.version>
         <ajp.port>8409</ajp.port>
         <amps.version>8.0.2</amps.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.0.34-SNAPSHOT</confapi-commons.version>
-        <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
+        <confapi-commons.version>0.0.34</confapi-commons.version>
+        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
     </properties>
 
     <dependencyManagement>
@@ -112,6 +112,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.28</version>
             <scope>provided</scope>
         </dependency>
 
@@ -120,28 +121,24 @@
         <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-api</artifactId>
-            <version>${crowd.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-core</artifactId>
-            <version>${crowd.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-rest-plugin</artifactId>
-            <version>${crowd.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.atlassian.scheduler</groupId>
             <artifactId>atlassian-scheduler-quartz1</artifactId>
-            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -201,6 +198,19 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>2.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- test dependencies -->
 
         <dependency>
@@ -214,19 +224,22 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <version>4.13.2</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>provided</scope>
+            <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <scope>provided</scope>
+            <version>1.3</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -238,15 +251,14 @@
         <dependency>
             <groupId>com.atlassian.crowd</groupId>
             <artifactId>crowd-test-utils</artifactId>
-            <version>${crowd.version}</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.atlassian.plugins</groupId>
             <artifactId>atlassian-plugins-osgi-testrunner</artifactId>
             <version>${plugin.testrunner.version}</version>
-            <scope>provided</scope>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>junit</groupId>
@@ -285,14 +297,6 @@
                         <Spring-Context>*</Spring-Context>
                     </instructions>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>copy-bundled-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
@@ -307,6 +311,15 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <scannedDependencies>
+                        <dependency>
+                            <groupId>com.atlassian.plugin</groupId>
+                            <artifactId>atlassian-spring-scanner-external-jar</artifactId>
+                        </dependency>
+                    </scannedDependencies>
+                    <verbose>false</verbose>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/src/main/resources/META-INF/spring/plugin-context.xml
@@ -3,8 +3,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
         xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.atlassian.com/schema/atlassian-scanner/2
-        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.atlassian.com/schema/atlassian-scanner
+        http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
     <atlassian-scanner:scan-indexes/>
 </beans>


### PR DESCRIPTION
This also requires to set some fixed version and to pull in some new dependencies, due to the use of the dependency management and  because the transitive version updates of dependencies would require a large set of changes.

Also, the spring scanner configuration needed to be fixed, otherwise Crowd 5 wouldn't load the plugin.