### PR TITLE
Upgrade Ubuntu, Java and GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,19 +11,20 @@ on:
 jobs:
   package:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: confapi-plugin-${{ hashFiles('**/pom.xml') }}
@@ -38,23 +39,24 @@ jobs:
   unit-tests:
     needs: package
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache Maven package
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: confapi-plugin-${{ hashFiles('**/pom.xml') }}
@@ -66,19 +68,21 @@ jobs:
   integration-tests:
     needs: package
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        # Crowd and thus the integration tests are not compatible with Java 17
         java-version: 11
+        distribution: temurin
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache Maven package
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: confapi-plugin-${{ hashFiles('**/pom.xml') }}
@@ -92,7 +96,7 @@ jobs:
 
     if: github.event_name == 'push' # to 'main'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
@@ -104,16 +108,17 @@ jobs:
       SIGN_ASC_IV: ${{ secrets.SIGN_ASC_IV }}
 
     steps:
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache Maven package
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: confapi-plugin-${{ hashFiles('**/pom.xml') }}
@@ -131,19 +136,20 @@ jobs:
   apcc:
     needs: package
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
+        distribution: temurin
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache Maven package
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2
         key: confapi-plugin-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,9 @@
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
         <confapi-commons.version>0.0.34</confapi-commons.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <!-- Compiler must be 8 so that the plugin can run on Crowd instances using Java 8 -->
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
Also configure Maven to compile for Java 8 to make plugin working on Crowd instances running with Java 8, and keep the integration tests running with Java 11 due to the incompatibility of Crowd and thus the tests with Java 17.