### PR TITLE
Allow setting users together with directories, improve users endpoint

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -3402,6 +3402,18 @@ endif::internal-generation[]
 | 
 |  
 
+| groups 
+|  
+| List  of <<GroupBean>> 
+| 
+|  
+
+| users 
+|  
+| List  of <<UserBean>> 
+| 
+|  
+
 | schema 
 |  
 | DirectoryLdapSchema  
@@ -4205,6 +4217,18 @@ endif::internal-generation[]
 | 
 |  
 
+| groups 
+|  
+| List  of <<GroupBean>> 
+| 
+|  
+
+| users 
+|  
+| List  of <<UserBean>> 
+| 
+|  
+
 |===
 
 
@@ -4515,6 +4539,37 @@ endif::internal-generation[]
 |===
 
 
+[#GroupBean]
+=== _GroupBean_ 
+
+
+
+[.fields-GroupBean]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| name 
+|  
+| String  
+| 
+|  
+
+| description 
+|  
+| String  
+| 
+|  
+
+| active 
+|  
+| Boolean  
+| 
+|  
+
+|===
+
+
 [#LicenseBean]
 === _LicenseBean_ 
 
@@ -4813,6 +4868,18 @@ endif::internal-generation[]
 | 
 |  
 
+| firstName 
+|  
+| String  
+| 
+|  
+
+| lastName 
+|  
+| String  
+| 
+|  
+
 | fullName 
 |  
 | String  
@@ -4828,6 +4895,12 @@ endif::internal-generation[]
 | password 
 |  
 | String  
+| 
+|  
+
+| groups 
+|  
+| List  of <<GroupBean>> 
 | 
 |  
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>confapi-crowd-plugin</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>ConfAPI for Crowd</name>
@@ -66,7 +66,7 @@
         <amps.version>8.0.2</amps.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.1.1</confapi-commons.version>
+        <confapi-commons.version>0.2.0-SNAPSHOT</confapi-commons.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <!-- Compiler must be 8 so that the plugin can run on Crowd instances using Java 8 -->
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/de/aservo/confapi/crowd/exception/NotFoundExceptionForDirectory.java
+++ b/src/main/java/de/aservo/confapi/crowd/exception/NotFoundExceptionForDirectory.java
@@ -1,0 +1,27 @@
+package de.aservo.confapi.crowd.exception;
+
+import de.aservo.confapi.commons.exception.NotFoundException;
+import de.aservo.confapi.commons.model.AbstractDirectoryBean;
+
+@SuppressWarnings("java:S110")
+public class NotFoundExceptionForDirectory extends NotFoundException {
+
+    public NotFoundExceptionForDirectory(
+            final AbstractDirectoryBean directoryBean) {
+
+        this(directoryBean.getName());
+    }
+
+    public NotFoundExceptionForDirectory(
+            final String name) {
+
+        super(String.format("Directory with name '%s' could not be found", name));
+    }
+
+    public NotFoundExceptionForDirectory(
+            final long id) {
+
+        super(String.format("Directory with id '%d' could not be found", id));
+    }
+
+}

--- a/src/main/java/de/aservo/confapi/crowd/exception/NotFoundExceptionForUser.java
+++ b/src/main/java/de/aservo/confapi/crowd/exception/NotFoundExceptionForUser.java
@@ -1,0 +1,21 @@
+package de.aservo.confapi.crowd.exception;
+
+import de.aservo.confapi.commons.exception.NotFoundException;
+import de.aservo.confapi.commons.model.UserBean;
+
+@SuppressWarnings("java:S110")
+public class NotFoundExceptionForUser extends NotFoundException {
+
+    public NotFoundExceptionForUser(
+            final UserBean userBean) {
+
+        this(userBean.getUsername());
+    }
+
+    public NotFoundExceptionForUser(
+            final String name) {
+
+        super(String.format("User with name '%s' could not be found", name));
+    }
+
+}

--- a/src/main/java/de/aservo/confapi/crowd/model/util/UserBeanUtil.java
+++ b/src/main/java/de/aservo/confapi/crowd/model/util/UserBeanUtil.java
@@ -3,7 +3,7 @@ package de.aservo.confapi.crowd.model.util;
 import com.atlassian.crowd.model.user.User;
 import de.aservo.confapi.commons.model.UserBean;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 public class UserBeanUtil {
 
@@ -13,18 +13,17 @@ public class UserBeanUtil {
      * @param user the user
      * @return the user bean
      */
-    @Nullable
+    @Nonnull
     public static UserBean toUserBean(
-            @Nullable final User user) {
-
-        if (user == null) {
-            return null;
-        }
+            @Nonnull final User user) {
 
         final UserBean userBean = new UserBean();
         userBean.setUsername(user.getName());
+        userBean.setFirstName(user.getFirstName());
+        userBean.setLastName(user.getLastName());
         userBean.setFullName(user.getDisplayName());
         userBean.setEmail(user.getEmailAddress());
+        userBean.setActive(user.isActive());
 
         return userBean;
     }

--- a/src/main/java/de/aservo/confapi/crowd/service/UsersServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/crowd/service/UsersServiceImpl.java
@@ -12,6 +12,7 @@ import com.atlassian.crowd.manager.directory.DirectoryManager;
 import com.atlassian.crowd.manager.directory.DirectoryPermissionException;
 import com.atlassian.crowd.model.user.User;
 import com.atlassian.crowd.model.user.UserTemplate;
+import com.atlassian.crowd.model.user.UserTemplateWithAttributes;
 import com.atlassian.crowd.search.EntityDescriptor;
 import com.atlassian.crowd.search.builder.QueryBuilder;
 import com.atlassian.crowd.search.query.entity.EntityQuery;
@@ -19,15 +20,19 @@ import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import de.aservo.confapi.commons.exception.BadRequestException;
 import de.aservo.confapi.commons.exception.InternalServerErrorException;
-import de.aservo.confapi.commons.exception.NotFoundException;
 import de.aservo.confapi.commons.model.UserBean;
 import de.aservo.confapi.commons.service.api.UsersService;
+import de.aservo.confapi.crowd.exception.NotFoundExceptionForDirectory;
+import de.aservo.confapi.crowd.exception.NotFoundExceptionForUser;
 import de.aservo.confapi.crowd.model.util.UserBeanUtil;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @ExportAsService(UsersService.class)
@@ -45,34 +50,116 @@ public class UsersServiceImpl implements UsersService {
 
     @Override
     public UserBean getUser(
-            final String name) {
+            final long directoryId,
+            final String username) {
 
-        return UserBeanUtil.toUserBean(findUser(name));
+        final User user = findUser(directoryId, username);
+
+        if (user == null) {
+            throw new NotFoundExceptionForUser(username);
+        }
+
+        return UserBeanUtil.toUserBean(user);
+    }
+
+    public UserBean setUser(
+            final long directoryId,
+            final UserBean userBean) {
+
+        final User user = findUser(directoryId, userBean.getUsername());
+
+        if (user == null) {
+            return addUser(directoryId, userBean);
+        }
+
+        return updateUser(directoryId, user.getName(), userBean);
     }
 
     @Override
-    public UserBean updateUser(
-            final String name,
+    public List<UserBean> setUsers(
+            final long directoryId,
+            final Collection<UserBean> userBeans) {
+
+        return userBeans.stream()
+                .map(userBean -> setUser(directoryId, userBean))
+                .collect(Collectors.toList());
+    }
+
+    public UserBean addUser(
+            final long directoryId,
             final UserBean userBean) {
 
-        User user = findUser(name);
+        return addUser(directoryId, userBean.getUsername(), userBean);
+    }
 
-        if (userBean.getUsername() != null && !name.equals(userBean.getUsername())) {
+    UserBean addUser(
+            final long directoryId,
+            final String username,
+            final UserBean userBean) {
+
+        User user = findUser(directoryId, userBean.getUsername());
+
+        if (user != null) {
+            throw new BadRequestException(String.format("User '%s' already exists", userBean.getUsername()));
+        }
+
+        if (userBean.getUsername() == null) {
+            if (username == null) {
+                throw new BadRequestException("Cannot create user, username is required");
+            }
+
+            userBean.setUsername(username);
+        }
+
+        if (username != null && !userBean.getUsername().equals(username)) {
+            throw new BadRequestException("Cannot create user, two different usernames provided");
+        }
+
+        if (userBean.getFirstName() == null || userBean.getLastName() == null || userBean.getFullName() == null || userBean.getEmail() == null) {
+            throw new BadRequestException("Cannot create user, first name, last name, display (full) name and email are required");
+        }
+
+        if (userBean.getPassword() == null) {
+            throw new BadRequestException("Cannot create user, password is required");
+        }
+
+        final UserTemplateWithAttributes userTemplate = new UserTemplateWithAttributes(userBean.getUsername(), directoryId);
+        userTemplate.setFirstName(userBean.getFirstName());
+        userTemplate.setLastName(userBean.getLastName());
+        userTemplate.setDisplayName(userBean.getFullName());
+        userTemplate.setEmailAddress(userBean.getEmail());
+        userTemplate.setActive(userBean.getActive() != null || userBean.getActive());
+
+        final PasswordCredential passwordCredential = PasswordCredential.unencrypted(userBean.getPassword());
+
+        try {
+            return UserBeanUtil.toUserBean(directoryManager.addUser(directoryId, userTemplate, passwordCredential));
+        } catch (InvalidCredentialException | InvalidUserException | DirectoryPermissionException | UserAlreadyExistsException e) {
+            throw new BadRequestException(e);
+        } catch (DirectoryNotFoundException e) {
+            throw new NotFoundExceptionForDirectory(directoryId);
+        } catch (OperationFailedException e) {
+            throw new InternalServerErrorException(e);
+        }
+    }
+
+    UserBean updateUser(
+            final long directoryId,
+            final String username,
+            final UserBean userBean) {
+
+        User user = findUser(directoryId, username);
+
+        if (user == null) {
+            throw new NotFoundExceptionForUser(username);
+        }
+
+        if (userBean.getUsername() != null && !username.equals(userBean.getUsername())) {
             user = renameUser(user, userBean.getUsername());
         }
 
-        if (userBean.getFullName() != null || userBean.getEmail() != null) {
-            final UserTemplate userTemplate = new UserTemplate(user);
-
-            if (userBean.getFullName() != null) {
-                userTemplate.setDisplayName(userBean.getFullName());
-            }
-
-            if (userBean.getEmail() != null) {
-                userTemplate.setEmailAddress(userBean.getEmail());
-            }
-
-            user = updateUser(user.getDirectoryId(), userTemplate);
+        if (userBean.getFirstName() != null || userBean.getLastName() != null || userBean.getFullName() != null || userBean.getEmail() != null) {
+            user = updateUser(user.getDirectoryId(), getUserTemplate(user, userBean));
         }
 
         if (userBean.getPassword() != null) {
@@ -82,23 +169,93 @@ public class UsersServiceImpl implements UsersService {
         return UserBeanUtil.toUserBean(user);
     }
 
+    @Nullable
+    User findUser(
+            final long directoryId,
+            final String username) {
+
+        try {
+            return directoryManager.findUserByName(directoryId, username);
+        } catch (DirectoryNotFoundException e) {
+            throw new NotFoundExceptionForDirectory(directoryId);
+        } catch (UserNotFoundException e) {
+            // Ignore, will be handled differently
+        } catch (OperationFailedException e) {
+            throw new InternalServerErrorException(e);
+        }
+
+        return null;
+    }
+
+    /**
+     * @deprecated (due to random directory selection)
+     */
     @Override
+    @Deprecated
+    public UserBean getUser(
+            final String username) {
+
+        final User user = findUserAllDirectories(username);
+
+        if (user == null) {
+            throw new NotFoundExceptionForUser(username);
+        }
+
+        return UserBeanUtil.toUserBean(user);
+    }
+
+    /*
+     * All the deprecated methods...
+     */
+
+    /**
+     * @deprecated (due to random directory selection)
+     */
+    @Override
+    @Deprecated
+    public UserBean updateUser(
+            final String username,
+            final UserBean userBean) {
+
+        final User user = findUserAllDirectories(username);
+
+        if (user == null) {
+            throw new NotFoundExceptionForUser(username);
+        }
+
+        return updateUser(user.getDirectoryId(), username, userBean);
+    }
+
+    /**
+     * @deprecated (due to random directory selection)
+     */
+    @Override
+    @Deprecated
     public UserBean updatePassword(
-            final String name,
+            final String username,
             final String password) {
 
-        final User user = findUser(name);
+        final User user = findUserAllDirectories(username);
+
+        if (user == null) {
+            throw new NotFoundExceptionForUser(username);
+        }
+
         updatePassword(user, password);
         return UserBeanUtil.toUserBean(user);
     }
 
-    @NotNull
-    private User findUser(
-            final String name) {
+    /**
+     * @deprecated (due to random directory selection)
+     */
+    @Nullable
+    @Deprecated
+    private User findUserAllDirectories(
+            final String username) {
 
         for (Directory directory : findDirectories()) {
             try {
-                return directoryManager.findUserByName(directory.getId(), name);
+                return directoryManager.findUserByName(directory.getId(), username);
             } catch (UserNotFoundException e) {
                 // Ignore, will be handled below
             } catch (DirectoryNotFoundException | OperationFailedException e) {
@@ -106,16 +263,16 @@ public class UsersServiceImpl implements UsersService {
             }
         }
 
-        throw new NotFoundException(String.format("User with name '%s' could not be found", name));
+        return null;
     }
 
     @NotNull
     private User renameUser(
-            final User user,
-            final String newName) {
+            final User username,
+            final String newUsername) {
 
         try {
-            return directoryManager.renameUser(user.getDirectoryId(), user.getName(), newName);
+            return directoryManager.renameUser(username.getDirectoryId(), username.getName(), newUsername);
         } catch (DirectoryPermissionException | UserAlreadyExistsException | InvalidUserException e) {
             // A permission exception should only happen if we try change the name
             // of a user in a read-only directory, so treat this as a bad request
@@ -145,7 +302,7 @@ public class UsersServiceImpl implements UsersService {
         }
     }
 
-    private void updatePassword(
+    void updatePassword(
             final User user,
             final String password) {
 
@@ -162,10 +319,44 @@ public class UsersServiceImpl implements UsersService {
         }
     }
 
+    private static UserTemplate getUserTemplate(
+            final User user,
+            final UserBean userBean) {
+
+        final UserTemplate userTemplate = new UserTemplate(user);
+
+        if (userBean.getFirstName() != null) {
+            userTemplate.setFirstName(userBean.getFirstName());
+        }
+
+        if (userBean.getLastName() != null) {
+            userTemplate.setLastName(userBean.getLastName());
+        }
+
+        if (userBean.getFullName() != null) {
+            userTemplate.setDisplayName(userBean.getFullName());
+        }
+
+        if (userBean.getEmail() != null) {
+            userTemplate.setEmailAddress(userBean.getEmail());
+        }
+
+        if (userBean.getActive() != null) {
+            userTemplate.setActive(userBean.getActive());
+        }
+
+        return userTemplate;
+    }
+
+    /**
+     * @deprecated (due to random directory selection)
+     */
+    @Deprecated
     private List<Directory> findDirectories() {
         final EntityQuery<Directory> directoryEntityQuery = QueryBuilder.queryFor(Directory.class, EntityDescriptor.directory())
                 .returningAtMost(EntityQuery.ALL_RESULTS);
 
         return directoryManager.searchDirectories(directoryEntityQuery);
     }
+
 }

--- a/src/test/java/de/aservo/confapi/crowd/model/util/UserBeanUtilTest.java
+++ b/src/test/java/de/aservo/confapi/crowd/model/util/UserBeanUtilTest.java
@@ -23,11 +23,6 @@ public class UserBeanUtilTest {
         assertEquals(user.getEmailAddress(), userBean.getEmail());
     }
 
-    @Test
-    public void testToUserBeanNull() {
-        assertNull(UserBeanUtil.toUserBean(null));
-    }
-
     private User getTestUser() {
         return ImmutableUser.builder(1, "test")
                 .displayName("Test User")

--- a/src/test/java/de/aservo/confapi/crowd/service/UsersServiceTest.java
+++ b/src/test/java/de/aservo/confapi/crowd/service/UsersServiceTest.java
@@ -16,8 +16,11 @@ import com.atlassian.crowd.manager.directory.DirectoryPermissionException;
 import com.atlassian.crowd.model.user.ImmutableUser;
 import com.atlassian.crowd.model.user.User;
 import com.atlassian.crowd.model.user.UserTemplate;
-import de.aservo.confapi.commons.exception.NotFoundException;
+import com.atlassian.crowd.model.user.UserTemplateWithAttributes;
+import de.aservo.confapi.commons.exception.BadRequestException;
 import de.aservo.confapi.commons.model.UserBean;
+import de.aservo.confapi.crowd.exception.NotFoundExceptionForUser;
+import de.aservo.confapi.crowd.model.util.UserBeanUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,11 +29,15 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.ws.rs.WebApplicationException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.spy;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UsersServiceTest {
@@ -56,12 +63,30 @@ public class UsersServiceTest {
         final User user = getTestUser();
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
 
+        final UserBean userBean = usersService.getUser(user.getDirectoryId(), user.getName());
+        assertEquals(user.getName(), userBean.getUsername());
+    }
+
+    @Test
+    public void testGetUserAnyDirectory() throws CrowdException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
         final UserBean userBean = usersService.getUser(user.getName());
         assertEquals(user.getName(), userBean.getUsername());
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test(expected = NotFoundExceptionForUser.class)
     public void testGetUserNotFound() throws Exception {
+        final Directory directory = getTestDirectory();
+        final String userName = "not_found";
+        doThrow(new UserNotFoundException(userName)).when(directoryManager).findUserByName(directory.getId(), userName);
+
+        usersService.getUser(directory.getId(), userName);
+    }
+
+    @Test(expected = NotFoundExceptionForUser.class)
+    public void testGetUserNotFoundAnyDirectory() throws Exception {
         final Directory directory = getTestDirectory();
         final String userName = "not_found";
         doThrow(new UserNotFoundException(userName)).when(directoryManager).findUserByName(directory.getId(), userName);
@@ -70,35 +95,210 @@ public class UsersServiceTest {
     }
 
     @Test
-    public void testUpdateUser() throws CrowdException, PermissionException {
+    public void testSetUserAddNew() {
         final User user = getTestUser();
-        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+        final UserBean userBean = UserBean.EXAMPLE_1;
+        final UsersServiceImpl spy = spy(usersService);
+        doReturn(userBean).when(spy).addUser(anyLong(), anyString(), any());
 
-        final UserBean userBean = new UserBean();
-        userBean.setFullName("Other Full Name");
-        userBean.setEmail("other@example.com");
-
-        final ArgumentCaptor<UserTemplate> userTemplateArgumentCaptor = ArgumentCaptor.forClass(UserTemplate.class);
-        usersService.updateUser(user.getName(), userBean);
-        verify(directoryManager).updateUser(anyLong(), userTemplateArgumentCaptor.capture());
-        assertEquals(userBean.getFullName(), userTemplateArgumentCaptor.getValue().getDisplayName());
-        assertEquals(userBean.getEmail(), userTemplateArgumentCaptor.getValue().getEmailAddress());
+        spy.setUser(user.getDirectoryId(), userBean);
+        verify(spy).addUser(anyLong(), anyString(), any());
     }
 
     @Test
-    public void testUpdateUserWithRename() throws CrowdException, PermissionException {
+    public void testSetUserUpdateExisting() throws CrowdException {
         final User user = getTestUser();
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        assertNotNull(userBean);
+
+        final UsersServiceImpl spy = spy(usersService);
+        doReturn(user).when(spy).findUser(user.getDirectoryId(), user.getName());
+        doReturn(userBean).when(spy).updateUser(user.getDirectoryId(), user.getName(), userBean);
+
+        spy.setUser(user.getDirectoryId(), userBean);
+        verify(spy).updateUser(anyLong(), anyString(), any());
+    }
+
+    @Test
+    public void testSetUsers() {
+        final User user = getTestUser();
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        userBean.setPassword("s3cr3t");
+
+        final List<UserBean> userBeans = new ArrayList<>();
+        userBeans.add(userBean);
+        userBeans.add(UserBean.EXAMPLE_1);
+        final UsersServiceImpl spy = spy(usersService);
+        doAnswer(invocation -> invocation.getArguments()[1]).when(spy).setUser(anyLong(), any());
+
+        spy.setUsers(user.getDirectoryId(), userBeans);
+        verify(spy, times(userBeans.size())).setUser(anyLong(), any());
+    }
+
+    @Test
+    public void testAddUser() throws CrowdException, DirectoryPermissionException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+        // return the same user as the one we are adding
+        doAnswer(invocation -> invocation.getArguments()[1]).when(directoryManager).addUser(anyLong(), any(), any());
+
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        userBean.setPassword("s3cr3t");
+
+        final ArgumentCaptor<UserTemplateWithAttributes> userTemplateArgumentCaptor = ArgumentCaptor.forClass(UserTemplateWithAttributes.class);
+        usersService.addUser(user.getDirectoryId(), userBean);
+        verify(directoryManager).addUser(anyLong(), userTemplateArgumentCaptor.capture(), any());
+        assertEquals(userBean.getFirstName(), userTemplateArgumentCaptor.getValue().getFirstName());
+        assertEquals(userBean.getLastName(), userTemplateArgumentCaptor.getValue().getLastName());
+        assertEquals(userBean.getFullName(), userTemplateArgumentCaptor.getValue().getDisplayName());
+        assertEquals(userBean.getEmail(), userTemplateArgumentCaptor.getValue().getEmailAddress());
+        assertEquals(userBean.getActive(), userTemplateArgumentCaptor.getValue().isActive());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testAddUserAlreadyExists() throws CrowdException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
 
-        final UserBean userBean = new UserBean();
-        userBean.setUsername("new_username");
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        usersService.addUser(user.getDirectoryId(), userBean);
+    }
 
-        usersService.updateUser(user.getName(), userBean);
-        verify(directoryManager).renameUser(user.getDirectoryId(), user.getName(), userBean.getUsername());
+    @Test(expected = BadRequestException.class)
+    public void testAddUserNoName() throws CrowdException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        userBean.setUsername(null);
+        usersService.addUser(user.getDirectoryId(), userBean);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testAddUserTwoDifferentNames() throws CrowdException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        usersService.addUser(user.getDirectoryId(), "Other", userBean);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testAddUserDetailMissing() throws CrowdException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        userBean.setFirstName(null);
+        usersService.addUser(user.getDirectoryId(), userBean);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testAddUserPasswordMissing() throws CrowdException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        userBean.setPassword(null);
+        usersService.addUser(user.getDirectoryId(), userBean);
+    }
+
+    @Test
+    public void testUpdateUser() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+        // return the same user as the one we are updating
+        doAnswer(invocation -> invocation.getArguments()[1]).when(directoryManager).updateUser(anyLong(), any());
+
+        final UserBean userBean = new UserBean();
+        userBean.setFirstName("Other");
+        userBean.setLastName("Full Name");
+        userBean.setFullName("Other Full Name");
+        userBean.setEmail("other@example.com");
+        userBean.setActive(false);
+
+        final ArgumentCaptor<UserTemplate> userTemplateArgumentCaptor = ArgumentCaptor.forClass(UserTemplate.class);
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+        verify(directoryManager).updateUser(anyLong(), userTemplateArgumentCaptor.capture());
+        assertEquals(userBean.getFirstName(), userTemplateArgumentCaptor.getValue().getFirstName());
+        assertEquals(userBean.getLastName(), userTemplateArgumentCaptor.getValue().getLastName());
+        assertEquals(userBean.getFullName(), userTemplateArgumentCaptor.getValue().getDisplayName());
+        assertEquals(userBean.getEmail(), userTemplateArgumentCaptor.getValue().getEmailAddress());
+        assertEquals(userBean.getActive(), userTemplateArgumentCaptor.getValue().isActive());
     }
 
     @Test
     public void testUpdateUserNoOp() throws CrowdException, PermissionException {
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setUsername(user.getName());
+
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+        verify(directoryManager, never()).renameUser(anyLong(), anyString(), anyString());
+        verify(directoryManager, never()).updateUser(anyLong(), any());
+        verify(directoryManager, never()).updateUserCredential(anyLong(), anyString(), any());
+    }
+
+    @Test(expected = NotFoundExceptionForUser.class)
+    public void testUpdateUserNotFound() throws CrowdException, PermissionException {
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+
+        final User user = getTestUser();
+        final UserBean userBean = UserBeanUtil.toUserBean(user);
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+    }
+
+    @Test
+    public void testUpdateUserAnyDirectory() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+        doAnswer(invocation -> invocation.getArguments()[1]).when(directoryManager).updateUser(anyLong(), any());
+
+        final UserBean userBean = new UserBean();
+        userBean.setFirstName("Other");
+        userBean.setLastName("Full Name");
+        userBean.setFullName("Other Full Name");
+        userBean.setEmail("other@example.com");
+        userBean.setActive(false);
+
+        final ArgumentCaptor<UserTemplate> userTemplateArgumentCaptor = ArgumentCaptor.forClass(UserTemplate.class);
+        usersService.updateUser(user.getName(), userBean);
+        verify(directoryManager).updateUser(anyLong(), userTemplateArgumentCaptor.capture());
+        assertEquals(userBean.getFirstName(), userTemplateArgumentCaptor.getValue().getFirstName());
+        assertEquals(userBean.getLastName(), userTemplateArgumentCaptor.getValue().getLastName());
+        assertEquals(userBean.getFullName(), userTemplateArgumentCaptor.getValue().getDisplayName());
+        assertEquals(userBean.getEmail(), userTemplateArgumentCaptor.getValue().getEmailAddress());
+        assertEquals(userBean.getActive(), userTemplateArgumentCaptor.getValue().isActive());
+    }
+
+    @Test
+    public void testUpdateUserAnyDirectoryWithRename() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(Collections.singletonList(getTestDirectory())).when(directoryManager).searchDirectories(any());
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setUsername("new_username");
+        doReturn(user).when(directoryManager).renameUser(user.getDirectoryId(), user.getName(), userBean.getUsername());
+
+        usersService.updateUser(user.getName(), userBean);
+        // we are just checking that the rename method was called
+        verify(directoryManager).renameUser(user.getDirectoryId(), user.getName(), userBean.getUsername());
+    }
+
+    @Test
+    public void testUpdateUserAnyDirectoryNoOp() throws CrowdException, PermissionException {
         final User user = getTestUser();
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
 
@@ -113,7 +313,7 @@ public class UsersServiceTest {
     }
 
     @Test
-    public void testUpdateUserWithPassword() throws CrowdException, PermissionException {
+    public void testUpdateUserAnyDirectoryWithPassword() throws CrowdException, PermissionException {
         final User user = getTestUser();
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
 
@@ -150,6 +350,14 @@ public class UsersServiceTest {
         final User user = getTestUser();
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
         doThrow(new DirectoryNotFoundException(user.getDirectoryId())).when(directoryManager).findUserByName(anyLong(), anyString());
+        usersService.getUser(user.getDirectoryId(), user.getName());
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testGetUserDirectoryNotFoundExceptionAnyDirectory() throws CrowdException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+        doThrow(new DirectoryNotFoundException(user.getDirectoryId())).when(directoryManager).findUserByName(anyLong(), anyString());
         usersService.getUser(user.getName());
     }
 
@@ -158,11 +366,31 @@ public class UsersServiceTest {
         final User user = getTestUser();
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
         doThrow(new OperationFailedException()).when(directoryManager).findUserByName(anyLong(), anyString());
+        usersService.getUser(user.getDirectoryId(), user.getName());
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testGetUserOperationFailedExceptionAnyDirectory() throws CrowdException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+        doThrow(new OperationFailedException()).when(directoryManager).findUserByName(anyLong(), anyString());
         usersService.getUser(user.getName());
     }
 
     @Test(expected = WebApplicationException.class)
     public void testRenameUserDirectoryPermissionException() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setUsername("new_username");
+
+        doThrow(new DirectoryPermissionException()).when(directoryManager).renameUser(anyLong(), anyString(), anyString());
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testRenameUserDirectoryPermissionExceptionAnyDirectory() throws CrowdException, PermissionException {
         final User user = getTestUser();
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
 
@@ -182,11 +410,35 @@ public class UsersServiceTest {
         userBean.setUsername("new_username");
 
         doThrow(new UserAlreadyExistsException(user.getDirectoryId(), userBean.getUsername())).when(directoryManager).renameUser(anyLong(), anyString(), anyString());
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testRenameUserUserAlreadyExistsExceptionAnyDirectory() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setUsername("new_username");
+
+        doThrow(new UserAlreadyExistsException(user.getDirectoryId(), userBean.getUsername())).when(directoryManager).renameUser(anyLong(), anyString(), anyString());
         usersService.updateUser(user.getName(), userBean);
     }
 
     @Test(expected = WebApplicationException.class)
     public void testRenameUserInvalidUserException() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setUsername("new_username");
+
+        doThrow(new InvalidUserException(user, "message")).when(directoryManager).renameUser(anyLong(), anyString(), anyString());
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testRenameUserInvalidUserExceptionAnyDirectory() throws CrowdException, PermissionException {
         final User user = getTestUser();
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
 
@@ -206,11 +458,43 @@ public class UsersServiceTest {
         userBean.setUsername("new_username");
 
         doThrow(new OperationFailedException()).when(directoryManager).renameUser(anyLong(), anyString(), anyString());
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testRenameUserOperationFailedExceptionAnyDirectory() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setUsername("new_username");
+
+        doThrow(new OperationFailedException()).when(directoryManager).renameUser(anyLong(), anyString(), anyString());
         usersService.updateUser(user.getName(), userBean);
     }
 
     @Test(expected = WebApplicationException.class)
     public void testUpdateUserDirectoryPermissionException() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setFullName("Other Full Name");
+
+        doThrow(new DirectoryPermissionException()).when(directoryManager).updateUser(anyLong(), any());
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testUpdateUserNotFoundExceptionAnyDirectory() throws CrowdException {
+        final User user = getTestUser();
+        final UserBean userBean = new UserBean();
+        userBean.setFullName("Other Full Name");
+        usersService.updateUser(user.getName(), userBean);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testUpdateUserDirectoryPermissionExceptionAnyDirectory() throws CrowdException, PermissionException {
         final User user = getTestUser();
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
 
@@ -230,6 +514,18 @@ public class UsersServiceTest {
         userBean.setFullName("Other Full Name");
 
         doThrow(new InvalidUserException(user, "message")).when(directoryManager).updateUser(anyLong(), any());
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testUpdateUserInvalidUserExceptionAnyDirectory() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setFullName("Other Full Name");
+
+        doThrow(new InvalidUserException(user, "message")).when(directoryManager).updateUser(anyLong(), any());
         usersService.updateUser(user.getName(), userBean);
     }
 
@@ -242,11 +538,41 @@ public class UsersServiceTest {
         userBean.setEmail("other@example.com");
 
         doThrow(new OperationFailedException()).when(directoryManager).updateUser(anyLong(), any());
+        usersService.updateUser(user.getDirectoryId(), user.getName(), userBean);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testUpdateUserOperationFailedExceptionAnyDirectory() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        final UserBean userBean = new UserBean();
+        userBean.setEmail("other@example.com");
+
+        doThrow(new OperationFailedException()).when(directoryManager).updateUser(anyLong(), any());
         usersService.updateUser(user.getName(), userBean);
     }
 
     @Test(expected = WebApplicationException.class)
+    public void testUpdatePasswordNotFoundException() throws CrowdException, DirectoryPermissionException {
+        final User user = getTestUser();
+        final String password = "pa55w0rd";
+        doThrow(new UserNotFoundException(user.getName())).when(directoryManager).updateUserCredential(user.getDirectoryId(), user.getName(), PasswordCredential.unencrypted(password));
+        usersService.updatePassword(user, password);
+    }
+
+    @Test(expected = WebApplicationException.class)
     public void testUpdatePasswordDirectoryPermissionException() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        final String password = "pa55w0rd";
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        doThrow(new DirectoryPermissionException()).when(directoryManager).updateUserCredential(anyLong(), anyString(), any());
+        usersService.updatePassword(user, password);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testUpdatePasswordDirectoryPermissionExceptionAnyDirectory() throws CrowdException, PermissionException {
         final User user = getTestUser();
         final String password = "pa55w0rd";
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
@@ -262,11 +588,31 @@ public class UsersServiceTest {
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
 
         doThrow(new InvalidCredentialException()).when(directoryManager).updateUserCredential(anyLong(), anyString(), any());
+        usersService.updatePassword(user, password);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testUpdatePasswordInvalidCredentialExceptionAnyDirectory() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        final String password = "pa55w0rd";
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        doThrow(new InvalidCredentialException()).when(directoryManager).updateUserCredential(anyLong(), anyString(), any());
         usersService.updatePassword(user.getName(), password);
     }
 
     @Test(expected = WebApplicationException.class)
     public void testUpdatePasswordOperationFailedException() throws CrowdException, PermissionException {
+        final User user = getTestUser();
+        final String password = "pa55w0rd";
+        doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
+
+        doThrow(new OperationFailedException()).when(directoryManager).updateUserCredential(anyLong(), anyString(), any());
+        usersService.updatePassword(user, password);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testUpdatePasswordOperationFailedExceptionAnyDirectory() throws CrowdException, PermissionException {
         final User user = getTestUser();
         final String password = "pa55w0rd";
         doReturn(user).when(directoryManager).findUserByName(user.getDirectoryId(), user.getName());
@@ -281,8 +627,11 @@ public class UsersServiceTest {
 
     private User getTestUser() {
         return ImmutableUser.builder(getTestDirectory().getId(), "test")
+                .firstName("Test")
+                .lastName("User")
                 .displayName("Test User")
                 .emailAddress("test@example.com")
+                .active(true)
                 .build();
     }
 }


### PR DESCRIPTION
Users (and groups) directly belong to a directory. Because of that, the cleanest way to declaratively add or update directory users (and groups) would be to set them as a child element of a directory. E.g.:

```
directories:
  internal:
    name: Internal Directory
    ...
    users:
      user1:
        password: ...
      user2:
        password: ...
```

With this change it is possible to set users together with directories, however still as lists (not as maps as in the example), and for groups this still needs to be implemented if needed.

Also improve the users endpoint itself and allow passing a directory ID when performing user actions. The old behaviour that didn't require a directory ID is inacurate because would just any random directory that contains a user with the given name, and thus the related methods have been deprecated.
