### PR TITLE
Fix and extend behavior for delegating directories

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -3979,6 +3979,42 @@ endif::internal-generation[]
 | 
 |  
 
+| groupDn 
+|  
+| String  
+| 
+|  
+
+| groupObjectClass 
+|  
+| String  
+| 
+|  
+
+| groupObjectFilter 
+|  
+| String  
+| 
+|  
+
+| groupNameAttribute 
+|  
+| String  
+| 
+|  
+
+| groupDescriptionAttribute 
+|  
+| String  
+| 
+|  
+
+| groupMembersAttribute 
+|  
+| String  
+| 
+|  
+
 |===
 
 
@@ -4022,6 +4058,12 @@ endif::internal-generation[]
 | 
 |  
 
+| synchronizeUsers 
+|  
+| Boolean  
+| 
+|  
+
 | synchronizeUserDetails 
 |  
 | Boolean  
@@ -4029,6 +4071,12 @@ endif::internal-generation[]
 |  
 
 | synchronizeGroupMemberships 
+|  
+| Boolean  
+| 
+|  
+
+| useUserMembershipAttribute 
 |  
 | Boolean  
 | 
@@ -4889,6 +4937,12 @@ endif::internal-generation[]
 | email 
 |  
 | String  
+| 
+|  
+
+| active 
+|  
+| Boolean  
 | 
 |  
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <amps.version>8.0.2</amps.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.2.0-SNAPSHOT</confapi-commons.version>
+        <confapi-commons.version>0.2.0</confapi-commons.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <!-- Compiler must be 8 so that the plugin can run on Crowd instances using Java 8 -->
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/test/java/de/aservo/confapi/crowd/model/util/DirectoryBeanUtilTest.java
+++ b/src/test/java/de/aservo/confapi/crowd/model/util/DirectoryBeanUtilTest.java
@@ -119,8 +119,10 @@ public class DirectoryBeanUtilTest {
         AssertUtil.assertEquals(directory.getValue(LDAPPropertiesMapper.LDAP_SECURE_KEY), LdapSecureMode.valueOf(directoryDelegatingBean.getConnector().getSsl().name()).getName(), firstParameterIsExpected);
         AssertUtil.assertEquals(directory.getValue(LDAPPropertiesMapper.LDAP_REFERRAL_KEY), String.valueOf(directoryDelegatingBean.getConnector().getUseNodeReferrals()), firstParameterIsExpected);
         AssertUtil.assertEquals(directory.getValue(LDAPPropertiesMapper.LDAP_NESTED_GROUPS_DISABLED), String.valueOf(directoryDelegatingBean.getConnector().getNestedGroupsDisabled()), firstParameterIsExpected);
-        AssertUtil.assertEquals(directory.getValue(SynchronisableDirectoryProperties.INCREMENTAL_SYNC_ENABLED), String.valueOf(directoryDelegatingBean.getConnector().getSynchronizeUserDetails()), firstParameterIsExpected);
-        AssertUtil.assertEquals(directory.getValue(LDAPPropertiesMapper.LDAP_USING_USER_MEMBERSHIP_ATTRIBUTE_FOR_GROUP_MEMBERSHIP), String.valueOf(directoryDelegatingBean.getConnector().getSynchronizeGroupMemberships()), firstParameterIsExpected);
+        AssertUtil.assertEquals(directory.getValue(DelegatedAuthenticationDirectory.ATTRIBUTE_CREATE_USER_ON_AUTH), String.valueOf(directoryDelegatingBean.getConnector().getSynchronizeUsers()), firstParameterIsExpected);
+        AssertUtil.assertEquals(directory.getValue(DelegatedAuthenticationDirectory.ATTRIBUTE_UPDATE_USER_ON_AUTH), String.valueOf(directoryDelegatingBean.getConnector().getSynchronizeUserDetails()), firstParameterIsExpected);
+        AssertUtil.assertEquals(directory.getValue(DelegatedAuthenticationDirectory.ATTRIBUTE_KEY_IMPORT_GROUPS), String.valueOf(directoryDelegatingBean.getConnector().getSynchronizeGroupMemberships()), firstParameterIsExpected);
+        AssertUtil.assertEquals(directory.getValue(LDAPPropertiesMapper.LDAP_USING_USER_MEMBERSHIP_ATTRIBUTE), String.valueOf(directoryDelegatingBean.getConnector().getUseUserMembershipAttribute()), firstParameterIsExpected);
         AssertUtil.assertEquals(directory.getValue(LDAPPropertiesMapper.LDAP_PAGEDRESULTS_KEY), String.valueOf(directoryDelegatingBean.getConnector().getUsePagedResults()), firstParameterIsExpected);
         AssertUtil.assertEquals(directory.getValue(LDAPPropertiesMapper.LDAP_PAGEDRESULTS_SIZE), String.valueOf(directoryDelegatingBean.getConnector().getPagedResultsSize()), firstParameterIsExpected);
         AssertUtil.assertEquals(directory.getValue(SynchronisableDirectoryProperties.READ_TIMEOUT_IN_MILLISECONDS), String.valueOf(directoryDelegatingBean.getConnector().getReadTimeoutInMillis()), firstParameterIsExpected);
@@ -146,6 +148,12 @@ public class DirectoryBeanUtilTest {
         AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.USER_EMAIL_KEY), directoryDelegatingBeanExpected.getConfiguration().getUserEmailAttribute(), firstParameterIsExpected);
         AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.USER_GROUP_KEY), directoryDelegatingBeanExpected.getConfiguration().getUserGroupAttribute(), firstParameterIsExpected);
         AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.LDAP_EXTERNAL_ID), directoryDelegatingBeanExpected.getConfiguration().getUserUniqueIdAttribute(), firstParameterIsExpected);
+        AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.GROUP_DN_ADDITION), directoryDelegatingBeanExpected.getConfiguration().getGroupDn(), firstParameterIsExpected);
+        AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.GROUP_OBJECTCLASS_KEY), directoryDelegatingBeanExpected.getConfiguration().getGroupObjectClass(), firstParameterIsExpected);
+        AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.GROUP_OBJECTFILTER_KEY), directoryDelegatingBeanExpected.getConfiguration().getGroupObjectFilter(), firstParameterIsExpected);
+        AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.GROUP_NAME_KEY), directoryDelegatingBeanExpected.getConfiguration().getGroupNameAttribute(), firstParameterIsExpected);
+        AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.GROUP_DESCRIPTION_KEY), directoryDelegatingBeanExpected.getConfiguration().getGroupDescriptionAttribute(), firstParameterIsExpected);
+        AssertUtil.assertEquals(directoryActual.getValue(LDAPPropertiesMapper.GROUP_USERNAMES_KEY), directoryDelegatingBeanExpected.getConfiguration().getGroupMembersAttribute(), firstParameterIsExpected);
     }
 
     private void assertDirectoryAllowedOperationsMatches(
@@ -175,8 +183,10 @@ public class DirectoryBeanUtilTest {
                 .setAttribute(LDAPPropertiesMapper.LDAP_SECURE_KEY, LdapSecureMode.START_TLS.getName())
                 .setAttribute(LDAPPropertiesMapper.LDAP_REFERRAL_KEY, String.valueOf(true))
                 .setAttribute(LDAPPropertiesMapper.LDAP_NESTED_GROUPS_DISABLED, String.valueOf(false))
-                .setAttribute(SynchronisableDirectoryProperties.INCREMENTAL_SYNC_ENABLED, String.valueOf(true))
-                .setAttribute(LDAPPropertiesMapper.LDAP_USING_USER_MEMBERSHIP_ATTRIBUTE_FOR_GROUP_MEMBERSHIP, String.valueOf(true))
+                .setAttribute(DelegatedAuthenticationDirectory.ATTRIBUTE_CREATE_USER_ON_AUTH, String.valueOf(false))
+                .setAttribute(DelegatedAuthenticationDirectory.ATTRIBUTE_UPDATE_USER_ON_AUTH, String.valueOf(false))
+                .setAttribute(DelegatedAuthenticationDirectory.ATTRIBUTE_KEY_IMPORT_GROUPS, String.valueOf(false))
+                .setAttribute(LDAPPropertiesMapper.LDAP_USING_USER_MEMBERSHIP_ATTRIBUTE, String.valueOf(false))
                 .setAttribute(LDAPPropertiesMapper.LDAP_PAGEDRESULTS_KEY, String.valueOf(true))
                 .setAttribute(LDAPPropertiesMapper.LDAP_PAGEDRESULTS_SIZE, String.valueOf(999L))
                 .setAttribute(SynchronisableDirectoryProperties.READ_TIMEOUT_IN_MILLISECONDS, String.valueOf(123000L))
@@ -197,6 +207,12 @@ public class DirectoryBeanUtilTest {
                 .setAttribute(LDAPPropertiesMapper.USER_EMAIL_KEY, "userEmail")
                 .setAttribute(LDAPPropertiesMapper.USER_GROUP_KEY, "userGroup")
                 .setAttribute(LDAPPropertiesMapper.LDAP_EXTERNAL_ID, "userUniqueId")
+                .setAttribute(LDAPPropertiesMapper.GROUP_DN_ADDITION, "groupDnAddition")
+                .setAttribute(LDAPPropertiesMapper.GROUP_OBJECTCLASS_KEY, "groupObjectClass")
+                .setAttribute(LDAPPropertiesMapper.GROUP_OBJECTFILTER_KEY, "groupObjectFilter")
+                .setAttribute(LDAPPropertiesMapper.GROUP_NAME_KEY, "groupName")
+                .setAttribute(LDAPPropertiesMapper.GROUP_DESCRIPTION_KEY, "groupDescription")
+                .setAttribute(LDAPPropertiesMapper.GROUP_USERNAMES_KEY, "groupMembers")
                 ;
 
         return directoryBuilder.build();


### PR DESCRIPTION
A few of the before used attributes were completely wrong, which is now fixed. Additionally, the new user sync flags from the commons library have been implemented. Furthermore, some directory type specific defaults have been set, and also the missing group attributes have been added.
