### PR TITLE
Fix groups endpoint collision by changing endpoint method

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -2246,7 +2246,7 @@ endif::internal-generation[]
 [.setGroups]
 ==== setGroups
     
-`PUT /groups`
+`PATCH /groups`
 
 Set groups
 
@@ -2255,7 +2255,7 @@ Set groups
 
 
 
-// markup not found, no include::{specDir}groups/PUT/spec.adoc[opts=optional]
+// markup not found, no include::{specDir}groups/PATCH/spec.adoc[opts=optional]
 
 
 
@@ -2312,6 +2312,112 @@ Set groups
 
 | 200
 | Returns the updated groups details
+|  <<GroupBean>>
+
+
+| 0
+| Returns a list of error messages.
+|  <<ErrorCollection>>
+
+|===         
+
+===== Samples
+
+
+// markup not found, no include::{snippetDir}groups/PATCH/http-request.adoc[opts=optional]
+
+
+// markup not found, no include::{snippetDir}groups/PATCH/http-response.adoc[opts=optional]
+
+
+
+// file not found, no * wiremock data link :groups/PATCH/PATCH.json[]
+
+
+ifdef::internal-generation[]
+===== Implementation
+
+// markup not found, no include::{specDir}groups/PATCH/implementation.adoc[opts=optional]
+
+
+endif::internal-generation[]
+
+
+[.updateGroup]
+==== updateGroup
+    
+`PUT /groups`
+
+Update a group
+
+===== Description 
+
+
+
+
+// markup not found, no include::{specDir}groups/PUT/spec.adoc[opts=optional]
+
+
+
+===== Parameters
+
+
+===== Body Parameter
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| GroupBean 
+|  <<GroupBean>> 
+| X 
+|  
+|  
+
+|===         
+
+
+
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| directoryId 
+|   
+| X 
+| null 
+|  
+
+| name 
+|   
+| X 
+| null 
+|  
+
+|===         
+
+
+===== Return Type
+
+<<GroupBean>>
+
+
+===== Content Type
+
+* application/json
+
+===== Responses
+
+.http response codes
+[cols="2,3,1"]
+|===         
+| Code | Message | Datatype 
+
+
+| 200
+| Returns the updated group details
 |  <<GroupBean>>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <amps.version>8.0.2</amps.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.2.2</confapi-commons.version>
+        <confapi-commons.version>0.3.0</confapi-commons.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <!-- Compiler must be 8 so that the plugin can run on Crowd instances using Java 8 -->
         <maven.compiler.source>8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <amps.version>8.0.2</amps.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <atlassian.spring.scanner.version>2.1.5</atlassian.spring.scanner.version>
-        <confapi-commons.version>0.2.0</confapi-commons.version>
+        <confapi-commons.version>0.2.2</confapi-commons.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <!-- Compiler must be 8 so that the plugin can run on Crowd instances using Java 8 -->
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/de/aservo/confapi/crowd/rest/api/GroupsResource.java
+++ b/src/main/java/de/aservo/confapi/crowd/rest/api/GroupsResource.java
@@ -1,6 +1,7 @@
 package de.aservo.confapi.crowd.rest.api;
 
 import de.aservo.confapi.commons.constants.ConfAPI;
+import de.aservo.confapi.commons.http.PATCH;
 import de.aservo.confapi.commons.model.ErrorCollection;
 import de.aservo.confapi.commons.model.GroupBean;
 import de.aservo.confapi.crowd.model.GroupsBean;
@@ -10,12 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -84,7 +80,7 @@ public interface GroupsResource {
             @NotNull @QueryParam("name") final String groupName,
             @NotNull final GroupBean groupBean);
 
-    @PUT
+    @PATCH
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(

--- a/src/main/java/de/aservo/confapi/crowd/util/AttributeUtil.java
+++ b/src/main/java/de/aservo/confapi/crowd/util/AttributeUtil.java
@@ -1,6 +1,7 @@
 package de.aservo.confapi.crowd.util;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,7 +33,7 @@ public class AttributeUtil {
     }
 
     public static String fromIntegerList(
-            @Nullable final List<Integer> value) {
+            @Nullable final Collection<Integer> value) {
 
         if (value == null) {
             return null;


### PR DESCRIPTION
The plugin didn't work anymore because the groups endpoint had two sub-endpoints that produced the same media type (used the same method). In order to avoid the collision, the `PATCH` method has been introduced in ConfAPI commons (as it's missing in the old JAX-RS library) that is now used for the `setGroups` endpoint.

The usage of this method for `setGroups` is now inconsistent with the existing `set<OBJECT>s` endpoints, however we will need to streamline the existing endpoints anyway and will change over existing endpoints to `PATCH` in a breaking major release also.

In general, `PATCH` is supposed to work a bit different than how we use it now. However, our already existing update endpoints (`PUT`) already supports updating only modified values such as `PATCH` would do. On the other hand, we could consider the whole instance, e.g. Crowd to be patched, so the method `PATCH` might be a reasonable choice.